### PR TITLE
Use createMock method to create PHPUnit mocks

### DIFF
--- a/src/Generators/Mocks/PhpUnitMockGenerator.php
+++ b/src/Generators/Mocks/PhpUnitMockGenerator.php
@@ -38,6 +38,6 @@ class PhpUnitMockGenerator implements MockGenerator, ImportFactoryAware
     {
         $mockedType = $this->importFactory->make($class, $type);
 
-        return "\$this->getMock({$mockedType->getFinalName()}::class)";
+        return "\$this->createMock({$mockedType->getFinalName()}::class)";
     }
 }

--- a/tests/Unit/Generators/Mocks/PhpUnitMockGeneratorTest.php
+++ b/tests/Unit/Generators/Mocks/PhpUnitMockGeneratorTest.php
@@ -68,6 +68,6 @@ class PhpUnitMockGeneratorTest extends TestCase
             ->once()
             ->andReturn('Foo');
 
-        $this->assertSame('$this->getMock(Foo::class)', $this->phpunitMockGenerator->generateMock($class, 'Foo'));
+        $this->assertSame('$this->createMock(Foo::class)', $this->phpunitMockGenerator->generateMock($class, 'Foo'));
     }
 }


### PR DESCRIPTION
## Proposed Changes

Use the `createMock` method to generate mock objects with PHPUnit. `getMock` has been removed in PHPUnit 6.

Very cool project btw. I was just getting annoyed by writing PHPUnit test boilerplate and was looking for a solution to automate it when I discovered this project has just been released recently 👍