### PR TITLE
Test generator can generate checks methods

### DIFF
--- a/src/Generators/Tests/AbstractTestGenerator.php
+++ b/src/Generators/Tests/AbstractTestGenerator.php
@@ -126,7 +126,16 @@ abstract class AbstractTestGenerator implements
      */
     public function canGenerateFor(ReflectionClass $reflectionClass): bool
     {
-        return ! ($reflectionClass->isInterface() || $reflectionClass->isAnonymous());
+        if ($reflectionClass->isInterface() || $reflectionClass->isAnonymous()) {
+            return false;
+        }
+
+        $class = $this->makeClass($reflectionClass);
+
+        return Reflect::methods($reflectionClass)
+            ->some(function (ReflectionMethod $reflectionMethod) use ($class) {
+                return $this->shouldAddMethod($class, $reflectionMethod);
+            });
     }
 
     /*


### PR DESCRIPTION
Related to paul-thebaud/phpunitgen-console#7

## Proposed Changes

- AbstractTestGenerator::canGenerate will now ensure there is at least one method to generate for;
