### PR TITLE
Fix doc type reflection

### DIFF
--- a/src/Reflection/ReflectionType.php
+++ b/src/Reflection/ReflectionType.php
@@ -113,8 +113,8 @@ class ReflectionType
 
         // Check if its nullable.
         $nullable = $stringTypes->contains('null');
-        // Reject null and mixed types, since they are not "real" types.
-        $stringTypes = $stringTypes->reject('null')->reject('mixed');
+        // Reject null type, since it is not a "real" types.
+        $stringTypes = $stringTypes->reject('null');
 
         if ($stringTypes->isEmpty()) {
             return null;

--- a/tests/Feature/Generators/Php8Features/Php8FeaturesTest.php
+++ b/tests/Feature/Generators/Php8Features/Php8FeaturesTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PhpUnitGen\Core\Feature\Generators\Php8Features;
+
+use PhpUnitGen\Core\Generators\Tests\Basic\BasicTestGenerator;
+use Tests\PhpUnitGen\Core\Feature\Generators\AbstractGeneratorTester;
+
+/**
+ * Class Php8FeaturesTest.
+ */
+class Php8FeaturesTest extends AbstractGeneratorTester
+{
+    public function testItGeneratesTests(): void
+    {
+        $this->assertGeneratedIs('Php8Features/Rendered', 'Php8Features/Source', [
+            'implementations' => BasicTestGenerator::implementations(),
+        ]);
+    }
+}

--- a/tests/Feature/Generators/TypesDetections/TypesDetectionsTest.php
+++ b/tests/Feature/Generators/TypesDetections/TypesDetectionsTest.php
@@ -2,19 +2,19 @@
 
 declare(strict_types=1);
 
-namespace Tests\PhpUnitGen\Core\Feature\Generators\Basic;
+namespace Tests\PhpUnitGen\Core\Feature\Generators\TypesDetections;
 
 use PhpUnitGen\Core\Generators\Tests\Basic\BasicTestGenerator;
 use Tests\PhpUnitGen\Core\Feature\Generators\AbstractGeneratorTester;
 
 /**
- * Class Php8FeaturesTestGeneratorTest.
+ * Class TypesDetectionsTest.
  */
-class Php8FeaturesTestGeneratorTest extends AbstractGeneratorTester
+class TypesDetectionsTest extends AbstractGeneratorTester
 {
     public function testItGeneratesTests(): void
     {
-        $this->assertGeneratedIs('Php8Features/Rendered', 'Php8Features/Source', [
+        $this->assertGeneratedIs('TypesDetections/Rendered', 'TypesDetections/Source', [
             'implementations' => BasicTestGenerator::implementations(),
         ]);
     }

--- a/tests/Feature/Resources/Generators/TypesDetections/Rendered.stub
+++ b/tests/Feature/Resources/Generators/TypesDetections/Rendered.stub
@@ -1,0 +1,204 @@
+<?php
+
+namespace Tests\Current;
+
+use App\Current\Other\OtherPost1;
+use App\Current\Other\OtherPost2;
+use App\Current\Post1;
+use App\Current\Post2;
+use App\Current\TypesDetectionStub;
+use App\Other\Bar1;
+use App\Other\Bar2;
+use App\Other\Far1;
+use App\Other\Far2;
+use App\Other\Foo1;
+use App\Other\Foo2;
+use Mockery;
+use Mockery\Mock;
+use ReflectionClass;
+use Tests\TestCase;
+use Throwable1;
+use Throwable2;
+
+/**
+ * Class TypesDetectionStubTest.
+ *
+ * @covers \App\Current\TypesDetectionStub
+ */
+class TypesDetectionStubTest extends TestCase
+{
+    /**
+     * @var TypesDetectionStub
+     */
+    protected $typesDetectionStub;
+
+    /**
+     * @var mixed
+     */
+    protected $noType;
+
+    /**
+     * @var mixed
+     */
+    protected $mixed;
+
+    /**
+     * @var int
+     */
+    protected $mixedUsesDoc;
+
+    /**
+     * @var int
+     */
+    protected $scalar;
+
+    /**
+     * @var int
+     */
+    protected $scalarNullable;
+
+    /**
+     * @var int
+     */
+    protected $scalarNullableOr;
+
+    /**
+     * @var int
+     */
+    protected $scalarFromDoc;
+
+    /**
+     * @var int
+     */
+    protected $scalarNullableOrFromDoc;
+
+    /**
+     * @var Post1|Mock
+     */
+    protected $currentClass;
+
+    /**
+     * @var Throwable1|Mock
+     */
+    protected $rootClass;
+
+    /**
+     * @var OtherPost1|Mock
+     */
+    protected $subClass;
+
+    /**
+     * @var Foo1|Mock
+     */
+    protected $importedClass;
+
+    /**
+     * @var Bar1|Mock
+     */
+    protected $aliasedClass;
+
+    /**
+     * @var Far1|Mock
+     */
+    protected $groupAliasedClass;
+
+    /**
+     * @var Post2|Mock
+     */
+    protected $currentClassFromDoc;
+
+    /**
+     * @var Throwable2|Mock
+     */
+    protected $rootClassFromDoc;
+
+    /**
+     * @var OtherPost2|Mock
+     */
+    protected $subClassFromDoc;
+
+    /**
+     * @var Foo2|Mock
+     */
+    protected $importedClassFromDoc;
+
+    /**
+     * @var Bar2|Mock
+     */
+    protected $aliasedClassFromDoc;
+
+    /**
+     * @var Far2|Mock
+     */
+    protected $groupAliasedClassFromDoc;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->noType = null;
+        $this->mixed = null;
+        $this->mixedUsesDoc = 42;
+        $this->scalar = 42;
+        $this->scalarNullable = 42;
+        $this->scalarNullableOr = 42;
+        $this->scalarFromDoc = 42;
+        $this->scalarNullableOrFromDoc = 42;
+        $this->currentClass = Mockery::mock(Post1::class);
+        $this->rootClass = Mockery::mock(Throwable1::class);
+        $this->subClass = Mockery::mock(OtherPost1::class);
+        $this->importedClass = Mockery::mock(Foo1::class);
+        $this->aliasedClass = Mockery::mock(Bar1::class);
+        $this->groupAliasedClass = Mockery::mock(Far1::class);
+        $this->currentClassFromDoc = Mockery::mock(Post2::class);
+        $this->rootClassFromDoc = Mockery::mock(Throwable2::class);
+        $this->subClassFromDoc = Mockery::mock(OtherPost2::class);
+        $this->importedClassFromDoc = Mockery::mock(Foo2::class);
+        $this->aliasedClassFromDoc = Mockery::mock(Bar2::class);
+        $this->groupAliasedClassFromDoc = Mockery::mock(Far2::class);
+        $this->typesDetectionStub = new TypesDetectionStub($this->noType, $this->mixed, $this->mixedUsesDoc, $this->scalar, $this->scalarNullable, $this->scalarNullableOr, $this->scalarFromDoc, $this->scalarNullableOrFromDoc, $this->currentClass, $this->rootClass, $this->subClass, $this->importedClass, $this->aliasedClass, $this->groupAliasedClass, $this->currentClassFromDoc, $this->rootClassFromDoc, $this->subClassFromDoc, $this->importedClassFromDoc, $this->aliasedClassFromDoc, $this->groupAliasedClassFromDoc);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        unset($this->typesDetectionStub);
+        unset($this->noType);
+        unset($this->mixed);
+        unset($this->mixedUsesDoc);
+        unset($this->scalar);
+        unset($this->scalarNullable);
+        unset($this->scalarNullableOr);
+        unset($this->scalarFromDoc);
+        unset($this->scalarNullableOrFromDoc);
+        unset($this->currentClass);
+        unset($this->rootClass);
+        unset($this->subClass);
+        unset($this->importedClass);
+        unset($this->aliasedClass);
+        unset($this->groupAliasedClass);
+        unset($this->currentClassFromDoc);
+        unset($this->rootClassFromDoc);
+        unset($this->subClassFromDoc);
+        unset($this->importedClassFromDoc);
+        unset($this->aliasedClassFromDoc);
+        unset($this->groupAliasedClassFromDoc);
+    }
+
+    public function testGetCurrentClass(): void
+    {
+        $expected = Mockery::mock(Post1::class);
+        $property = (new ReflectionClass(TypesDetectionStub::class))
+            ->getProperty('currentClass');
+        $property->setAccessible(true);
+        $property->setValue($this->typesDetectionStub, $expected);
+        $this->assertSame($expected, $this->typesDetectionStub->getCurrentClass());
+    }
+}

--- a/tests/Feature/Resources/Generators/TypesDetections/Source.stub
+++ b/tests/Feature/Resources/Generators/TypesDetections/Source.stub
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Current;
+
+use App\Other\{ Far1 as Faz1 };
+use App\Other\Foo1;
+use App\Other\Bar1 as Baz1;
+use App\Other\{ Far2 as Faz2 };
+use App\Other\Foo2;
+use App\Other\Bar2 as Baz2;
+
+/**
+ * Class TypesDetectionStub.
+ */
+class TypesDetectionStub
+{
+    /**
+     * @param int $mixedUsesDoc
+     * @param int $scalarFromDoc
+     * @param int|null $scalarNullableOrFromDoc
+     * @param Post2 $currentClassFromDoc
+     * @param \Throwable2 $rootClassFromDoc
+     * @param Other\OtherPost2 $subClassFromDoc
+     * @param Foo2 $importedClassFromDoc
+     * @param Baz2 $aliasedClassFromDoc
+     * @param Faz2 $groupAliasedClassFromDoc
+     */
+    public function __construct(
+        protected $noType,
+        protected mixed $mixed,
+        protected mixed $mixedUsesDoc,
+        protected int $scalar,
+        protected ?int $scalarNullable,
+        protected int|null $scalarNullableOr,
+        protected $scalarFromDoc,
+        protected $scalarNullableOrFromDoc,
+        protected Post1 $currentClass,
+        protected \Throwable1 $rootClass,
+        protected Other\OtherPost1 $subClass,
+        protected Foo1 $importedClass,
+        protected Baz1 $aliasedClass,
+        protected Faz1 $groupAliasedClass,
+        protected $currentClassFromDoc,
+        protected $rootClassFromDoc,
+        protected $subClassFromDoc,
+        protected $importedClassFromDoc,
+        protected $aliasedClassFromDoc,
+        protected $groupAliasedClassFromDoc,
+    ) {}
+
+    public function getCurrentClass(): Post1
+    {
+    }
+}

--- a/tests/Unit/Generators/Factories/DocumentationFactoryTest.php
+++ b/tests/Unit/Generators/Factories/DocumentationFactoryTest.php
@@ -6,6 +6,7 @@ namespace Tests\PhpUnitGen\Core\Unit\Generators\Factories;
 
 use Mockery;
 use Mockery\Mock;
+use PhpParser\Node\Stmt\Namespace_;
 use PhpUnitGen\Core\Contracts\Config\Config;
 use PhpUnitGen\Core\Generators\Factories\DocumentationFactory;
 use PhpUnitGen\Core\Models\TestClass;
@@ -63,6 +64,9 @@ class DocumentationFactoryTest extends TestCase
         $reflectionClass->shouldReceive('getDocComment')
             ->withNoArgs()
             ->andReturn('');
+        $reflectionClass->shouldReceive('getDeclaringNamespaceAst')
+            ->withNoArgs()
+            ->andReturn(new Namespace_());
 
         $class->shouldReceive('getShortName')
             ->withNoArgs()
@@ -95,6 +99,9 @@ class DocumentationFactoryTest extends TestCase
         $reflectionClass->shouldReceive('getName')
             ->withNoArgs()
             ->andReturn('App\\Foo');
+        $reflectionClass->shouldReceive('getDeclaringNamespaceAst')
+            ->withNoArgs()
+            ->andReturn(new Namespace_());
         $reflectionClass->shouldReceive('getDocComment')
             ->withNoArgs()
             ->andReturn("/**\n * @author John\n * @since 1.0.0\n * @internal\n*/");

--- a/tests/Unit/Generators/Factories/MethodFactoryTest.php
+++ b/tests/Unit/Generators/Factories/MethodFactoryTest.php
@@ -175,18 +175,19 @@ class MethodFactoryTest extends TestCase
             'isPublic'      => true,
             'isAbstract'    => false,
             'isStatic'      => false,
+            'getDocComment' => '',
             'getParameters' => [$reflectionParameter1, $reflectionParameter2],
         ]);
 
         $reflectionParameter1->shouldReceive([
-            'getType'          => null,
-            'getDocBlockTypes' => [],
-            'getName'          => 'bar',
+            'getType'              => null,
+            'getName'              => 'bar',
+            'getDeclaringFunction' => $reflectionMethod,
         ]);
         $reflectionParameter2->shouldReceive([
-            'getType'          => $reflectionType,
-            'getDocBlockTypes' => [],
-            'getName'          => 'baz',
+            'getType'              => $reflectionType,
+            'getName'              => 'baz',
+            'getDeclaringFunction' => $reflectionMethod,
         ]);
 
         $reflectionType->shouldReceive([

--- a/tests/Unit/Generators/Factories/PropertyFactoryTest.php
+++ b/tests/Unit/Generators/Factories/PropertyFactoryTest.php
@@ -15,6 +15,7 @@ use PhpUnitGen\Core\Models\TestDocumentation;
 use PhpUnitGen\Core\Models\TestImport;
 use PhpUnitGen\Core\Models\TestProperty;
 use Roave\BetterReflection\Reflection\ReflectionClass;
+use Roave\BetterReflection\Reflection\ReflectionMethod;
 use Roave\BetterReflection\Reflection\ReflectionParameter;
 use Roave\BetterReflection\Reflection\ReflectionType;
 use Tests\PhpUnitGen\Core\Helpers\PhpVersionDependents;
@@ -102,6 +103,7 @@ class PropertyFactoryTest extends TestCase
         TestImport $expectedTypeHint
     ): void {
         $reflectionClass = Mockery::mock(ReflectionClass::class);
+        $reflectionMethod = Mockery::mock(ReflectionMethod::class);
         $reflectionParameter = Mockery::mock(ReflectionParameter::class);
         $doc = Mockery::mock(TestDocumentation::class);
         $mockImport = Mockery::mock(TestImport::class);
@@ -112,10 +114,14 @@ class PropertyFactoryTest extends TestCase
             'getName' => 'App\\Foo',
         ]);
 
+        $reflectionMethod->shouldReceive([
+            'getDocComment' => '',
+        ]);
+
         $reflectionParameter->shouldReceive([
-            'getName'          => 'bar',
-            'getType'          => $reflectionType,
-            'getDocBlockTypes' => [],
+            'getName'              => 'bar',
+            'getType'              => $reflectionType,
+            'getDeclaringFunction' => $reflectionMethod,
         ]);
 
         $this->importFactory->shouldReceive('make')
@@ -181,6 +187,7 @@ class PropertyFactoryTest extends TestCase
         string $expectedTypeHint
     ): void {
         $reflectionClass = Mockery::mock(ReflectionClass::class);
+        $reflectionMethod = Mockery::mock(ReflectionMethod::class);
         $reflectionParameter = Mockery::mock(ReflectionParameter::class);
         $doc = Mockery::mock(TestDocumentation::class);
 
@@ -190,10 +197,14 @@ class PropertyFactoryTest extends TestCase
             'getName' => 'App\\Foo',
         ]);
 
+        $reflectionMethod->shouldReceive([
+            'getDocComment' => '',
+        ]);
+
         $reflectionParameter->shouldReceive([
-            'getName'          => 'bar',
-            'getType'          => $reflectionType,
-            'getDocBlockTypes' => [],
+            'getName'              => 'bar',
+            'getType'              => $reflectionType,
+            'getDeclaringFunction' => $reflectionMethod,
         ]);
 
         $this->documentationFactory->shouldReceive('makeForProperty')

--- a/tests/Unit/Generators/Tests/Basic/BasicMethodFactoryTest.php
+++ b/tests/Unit/Generators/Tests/Basic/BasicMethodFactoryTest.php
@@ -112,11 +112,11 @@ class BasicMethodFactoryTest extends TestCase
         ]);
 
         $reflectionMethod->shouldReceive([
-            'getShortName'           => 'getBar',
-            'getDeclaringClass'      => $class->getReflectionClass(),
-            'getReturnType'          => null,
-            'getDocBlockReturnTypes' => [],
-            'isStatic'               => $isStatic,
+            'getShortName'      => 'getBar',
+            'getDeclaringClass' => $class->getReflectionClass(),
+            'getReturnType'     => null,
+            'getDocComment'     => '',
+            'isStatic'          => $isStatic,
         ]);
 
         $reflectionProperty->shouldReceive([
@@ -218,12 +218,13 @@ class BasicMethodFactoryTest extends TestCase
             'getShortName'      => 'setBar',
             'getDeclaringClass' => $class->getReflectionClass(),
             'getParameters'     => [$reflectionParameter],
+            'getDocComment'     => '',
             'isStatic'          => $isStatic,
         ]);
 
         $reflectionParameter->shouldReceive([
-            'getType'          => null,
-            'getDocBlockTypes' => [],
+            'getType'              => null,
+            'getDeclaringFunction' => $reflectionMethod,
         ]);
 
         $reflectionProperty->shouldReceive([

--- a/tests/Unit/Generators/Tests/Laravel/Channel/ChannelMethodFactoryTest.php
+++ b/tests/Unit/Generators/Tests/Laravel/Channel/ChannelMethodFactoryTest.php
@@ -146,11 +146,11 @@ class ChannelMethodFactoryTest extends TestCase
         ]);
 
         $reflectionMethod->shouldReceive([
-            'getShortName'           => 'getBar',
-            'getDeclaringClass'      => $class->getReflectionClass(),
-            'getReturnType'          => null,
-            'getDocBlockReturnTypes' => [],
-            'isStatic'               => false,
+            'getShortName'      => 'getBar',
+            'getDeclaringClass' => $class->getReflectionClass(),
+            'getReturnType'     => null,
+            'getDocComment'     => '',
+            'isStatic'          => false,
         ]);
 
         $reflectionProperty->shouldReceive([
@@ -197,11 +197,10 @@ class ChannelMethodFactoryTest extends TestCase
         ]);
 
         $reflectionMethod->shouldReceive([
-            'getShortName'           => 'bar',
-            'getDeclaringClass'      => $class->getReflectionClass(),
-            'getReturnType'          => null,
-            'getDocBlockReturnTypes' => [],
-            'isStatic'               => true,
+            'getShortName'      => 'bar',
+            'getDeclaringClass' => $class->getReflectionClass(),
+            'getReturnType'     => null,
+            'isStatic'          => true,
         ]);
 
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Unit/Generators/Tests/Laravel/Command/CommandMethodFactoryTest.php
+++ b/tests/Unit/Generators/Tests/Laravel/Command/CommandMethodFactoryTest.php
@@ -128,11 +128,11 @@ class CommandMethodFactoryTest extends TestCase
         ]);
 
         $reflectionMethod->shouldReceive([
-            'getShortName'           => 'getBar',
-            'getDeclaringClass'      => $class->getReflectionClass(),
-            'getReturnType'          => null,
-            'getDocBlockReturnTypes' => [],
-            'isStatic'               => false,
+            'getShortName'      => 'getBar',
+            'getDeclaringClass' => $class->getReflectionClass(),
+            'getReturnType'     => null,
+            'getDocComment'     => '',
+            'isStatic'          => false,
         ]);
 
         $reflectionProperty->shouldReceive([
@@ -179,11 +179,10 @@ class CommandMethodFactoryTest extends TestCase
         ]);
 
         $reflectionMethod->shouldReceive([
-            'getShortName'           => 'bar',
-            'getDeclaringClass'      => $class->getReflectionClass(),
-            'getReturnType'          => null,
-            'getDocBlockReturnTypes' => [],
-            'isStatic'               => true,
+            'getShortName'      => 'bar',
+            'getDeclaringClass' => $class->getReflectionClass(),
+            'getReturnType'     => null,
+            'isStatic'          => true,
         ]);
 
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Unit/Generators/Tests/Laravel/Policy/PolicyMethodFactoryTest.php
+++ b/tests/Unit/Generators/Tests/Laravel/Policy/PolicyMethodFactoryTest.php
@@ -150,11 +150,11 @@ class PolicyMethodFactoryTest extends TestCase
         ]);
 
         $reflectionMethod->shouldReceive([
-            'getShortName'           => 'getBar',
-            'getDeclaringClass'      => $class->getReflectionClass(),
-            'getReturnType'          => null,
-            'getDocBlockReturnTypes' => [],
-            'isStatic'               => false,
+            'getShortName'      => 'getBar',
+            'getDeclaringClass' => $class->getReflectionClass(),
+            'getReturnType'     => null,
+            'getDocComment'     => '',
+            'isStatic'          => false,
         ]);
 
         $reflectionProperty->shouldReceive([
@@ -201,11 +201,11 @@ class PolicyMethodFactoryTest extends TestCase
         ]);
 
         $reflectionMethod->shouldReceive([
-            'getShortName'           => 'bar',
-            'getDeclaringClass'      => $class->getReflectionClass(),
-            'getReturnType'          => null,
-            'getDocBlockReturnTypes' => [],
-            'isStatic'               => true,
+            'getShortName'      => 'bar',
+            'getDeclaringClass' => $class->getReflectionClass(),
+            'getReturnType'     => null,
+            'getDocComment'     => '',
+            'isStatic'          => true,
         ]);
 
         $this->expectException(InvalidArgumentException::class);
@@ -229,18 +229,18 @@ class PolicyMethodFactoryTest extends TestCase
         ]);
 
         $reflectionMethod->shouldReceive([
-            'getShortName'           => 'bar',
-            'getDeclaringClass'      => $class->getReflectionClass(),
-            'getReturnType'          => null,
-            'getDocBlockReturnTypes' => [],
-            'isStatic'               => false,
-            'getParameters'          => [$reflectionParamUser],
+            'getShortName'      => 'bar',
+            'getDeclaringClass' => $class->getReflectionClass(),
+            'getReturnType'     => null,
+            'getDocComment'     => '',
+            'isStatic'          => false,
+            'getParameters'     => [$reflectionParamUser],
         ]);
 
         $reflectionParamUser->shouldReceive([
-            'getName'          => 'user',
-            'getType'          => $reflectionTypeUser,
-            'getDocBlockTypes' => [],
+            'getName'              => 'user',
+            'getType'              => $reflectionTypeUser,
+            'getDeclaringFunction' => $reflectionMethod,
         ]);
 
         $this->statementFactory->shouldReceive('makeTodo')
@@ -300,23 +300,23 @@ class PolicyMethodFactoryTest extends TestCase
         ]);
 
         $reflectionMethod->shouldReceive([
-            'getShortName'           => 'bar',
-            'getDeclaringClass'      => $class->getReflectionClass(),
-            'getReturnType'          => null,
-            'getDocBlockReturnTypes' => [],
-            'isStatic'               => false,
-            'getParameters'          => [$reflectionParamUser, $reflectionParamProduct],
+            'getShortName'      => 'bar',
+            'getDeclaringClass' => $class->getReflectionClass(),
+            'getReturnType'     => null,
+            'getDocComment'     => '',
+            'isStatic'          => false,
+            'getParameters'     => [$reflectionParamUser, $reflectionParamProduct],
         ]);
 
         $reflectionParamUser->shouldReceive([
-            'getName'          => 'user',
-            'getType'          => $reflectionTypeUser,
-            'getDocBlockTypes' => [],
+            'getName'              => 'user',
+            'getType'              => $reflectionTypeUser,
+            'getDeclaringFunction' => $reflectionMethod,
         ]);
         $reflectionParamProduct->shouldReceive([
-            'getName'          => 'product',
-            'getType'          => $reflectionTypeProduct,
-            'getDocBlockTypes' => [],
+            'getName'              => 'product',
+            'getType'              => $reflectionTypeProduct,
+            'getDeclaringFunction' => $reflectionMethod,
         ]);
 
         $reflectionTypeProduct->shouldReceive([
@@ -397,28 +397,28 @@ class PolicyMethodFactoryTest extends TestCase
         ]);
 
         $reflectionMethod->shouldReceive([
-            'getShortName'           => 'bar',
-            'getDeclaringClass'      => $class->getReflectionClass(),
-            'getReturnType'          => null,
-            'getDocBlockReturnTypes' => [],
-            'isStatic'               => false,
-            'getParameters'          => [$reflectionParamUser, $reflectionParamProduct, $reflectionParamCategory],
+            'getShortName'      => 'bar',
+            'getDeclaringClass' => $class->getReflectionClass(),
+            'getReturnType'     => null,
+            'getDocComment'     => '',
+            'isStatic'          => false,
+            'getParameters'     => [$reflectionParamUser, $reflectionParamProduct, $reflectionParamCategory],
         ]);
 
         $reflectionParamUser->shouldReceive([
-            'getName'          => 'user',
-            'getType'          => $reflectionTypeUser,
-            'getDocBlockTypes' => [],
+            'getName'              => 'user',
+            'getType'              => $reflectionTypeUser,
+            'getDeclaringFunction' => $reflectionMethod,
         ]);
         $reflectionParamProduct->shouldReceive([
-            'getName'          => 'product',
-            'getType'          => $reflectionTypeProduct,
-            'getDocBlockTypes' => [],
+            'getName'              => 'product',
+            'getType'              => $reflectionTypeProduct,
+            'getDeclaringFunction' => $reflectionMethod,
         ]);
         $reflectionParamCategory->shouldReceive([
-            'getName'          => 'category',
-            'getType'          => $reflectionTypeCategory,
-            'getDocBlockTypes' => [],
+            'getName'              => 'category',
+            'getType'              => $reflectionTypeCategory,
+            'getDeclaringFunction' => $reflectionMethod,
         ]);
 
         $reflectionTypeProduct->shouldReceive([

--- a/tests/Unit/Reflection/ReflectionTypeTest.php
+++ b/tests/Unit/Reflection/ReflectionTypeTest.php
@@ -52,8 +52,6 @@ class ReflectionTypeTest extends TestCase
         $reflectionType = ReflectionType::make(null, [
             'null',
             'null',
-            'mixed',
-            'null',
         ]);
 
         $this->assertNull($reflectionType);


### PR DESCRIPTION
## Proposed Changes

  - BetterReflection V5 won't parse doc types anymore. This PR fixes this.
