### PR TITLE
feat: add final and declare strict types options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,15 @@
 # Change Log
 
-## 2.0.0
+## 3.0.0
 
-**Changed**
+**Added**
 
-- Add support for PHP `~8.0.12` and `~8.1.0`.
-- Drop support for PHP `7`.
-- When param or return `native` type is `mixed` or `object`, use the documentation type if available.
-- Test generator will now ensure public and testable methods exists in class in `canGenerate`.
-- Handle doc type resolving inside PhpUnitGen since BetterReflection V5 does not do this anymore.
+- Add `testClassFinal` option and update rendering to create final test class (see #19).
+- Add `testClassStrictTypes` option and update rendering to prepend strict types declaration test class (see #19).
 
-**Fixed**
+## 2.x.x
 
-- Laravel Controller test generator will correctly handle API controllers.
+See the [2.x.x CHANGELOG](https://github.com/paul-thebaud/phpunitgen-core/blob/2.x.x/CHANGELOG.md).
 
 ## 1.x.x
 

--- a/config/phpunitgen.php
+++ b/config/phpunitgen.php
@@ -11,7 +11,7 @@ return [
      | complex tests skeleton (getter/setter tests...).
      |--------------------------------------------------------------------------
      */
-    'automaticGeneration' => true,
+    'automaticGeneration'  => true,
 
     /*
      |--------------------------------------------------------------------------
@@ -21,7 +21,7 @@ return [
      | specific contract.
      |--------------------------------------------------------------------------
      */
-    'implementations'     => DelegateTestGenerator::implementations(),
+    'implementations'      => DelegateTestGenerator::implementations(),
 
     /*
      |--------------------------------------------------------------------------
@@ -30,7 +30,7 @@ return [
      | This string will be removed from the test class namespace.
      |--------------------------------------------------------------------------
      */
-    'baseNamespace'       => 'App',
+    'baseNamespace'        => 'App',
 
     /*
      |--------------------------------------------------------------------------
@@ -39,7 +39,7 @@ return [
      | This string will be prepend to the test class namespace.
      |--------------------------------------------------------------------------
      */
-    'baseTestNamespace'   => 'Tests',
+    'baseTestNamespace'    => 'Tests',
 
     /*
      |--------------------------------------------------------------------------
@@ -48,7 +48,25 @@ return [
      | The absolute class name to TestCase.
      |--------------------------------------------------------------------------
      */
-    'testCase'            => 'Tests\\TestCase',
+    'testCase'             => 'Tests\\TestCase',
+
+    /*
+     |--------------------------------------------------------------------------
+     | Test class final.
+     |
+     | Tells if the test class should be final.
+     |--------------------------------------------------------------------------
+     */
+    'testClassFinal'       => true,
+
+    /*
+     |--------------------------------------------------------------------------
+     | Test class strict types.
+     |
+     | Tells if the test class should declare strict types.
+     |--------------------------------------------------------------------------
+     */
+    'testClassStrictTypes' => false,
 
     /*
      |--------------------------------------------------------------------------
@@ -59,7 +77,7 @@ return [
      | closing "/", as they will be added automatically.
      |--------------------------------------------------------------------------
      */
-    'excludedMethods'     => [
+    'excludedMethods'      => [
         '__construct',
         '__destruct',
     ],
@@ -72,7 +90,7 @@ return [
      | to the test class documentation.
      |--------------------------------------------------------------------------
      */
-    'mergedPhpDoc'        => [
+    'mergedPhpDoc'         => [
         'author',
         'copyright',
         'license',
@@ -87,7 +105,7 @@ return [
      | added to the test class documentation.
      |--------------------------------------------------------------------------
      */
-    'phpDoc'              => [],
+    'phpDoc'               => [],
 
     /*
      |--------------------------------------------------------------------------
@@ -97,7 +115,7 @@ return [
      | contains any other useful information for test generation.
      |--------------------------------------------------------------------------
      */
-    'options'             => [
+    'options'              => [
         /*
          |----------------------------------------------------------------------
          | Context.

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -35,15 +35,17 @@ class Config implements ConfigContract
      * The properties of the config with there type hint.
      */
     protected const PROPERTIES = [
-        'automaticGeneration' => self::TYPE_BOOL,
-        'implementations'     => self::TYPE_ARRAY,
-        'baseNamespace'       => self::TYPE_STRING,
-        'baseTestNamespace'   => self::TYPE_STRING,
-        'testCase'            => self::TYPE_STRING,
-        'excludedMethods'     => self::TYPE_ARRAY,
-        'mergedPhpDoc'        => self::TYPE_ARRAY,
-        'phpDoc'              => self::TYPE_ARRAY,
-        'options'             => self::TYPE_ARRAY,
+        'automaticGeneration'  => self::TYPE_BOOL,
+        'implementations'      => self::TYPE_ARRAY,
+        'baseNamespace'        => self::TYPE_STRING,
+        'baseTestNamespace'    => self::TYPE_STRING,
+        'testCase'             => self::TYPE_STRING,
+        'testClassFinal'       => self::TYPE_BOOL,
+        'testClassStrictTypes' => self::TYPE_BOOL,
+        'excludedMethods'      => self::TYPE_ARRAY,
+        'mergedPhpDoc'         => self::TYPE_ARRAY,
+        'phpDoc'               => self::TYPE_ARRAY,
+        'options'              => self::TYPE_ARRAY,
     ];
 
     /**
@@ -158,6 +160,22 @@ class Config implements ConfigContract
     public function testCase(): string
     {
         return $this->config['testCase'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testClassFinal(): bool
+    {
+        return $this->config['testClassFinal'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testClassStrictTypes(): bool
+    {
+        return $this->config['testClassStrictTypes'];
     }
 
     /**

--- a/src/Contracts/Config/Config.php
+++ b/src/Contracts/Config/Config.php
@@ -51,6 +51,20 @@ interface Config
     public function testCase(): string;
 
     /**
+     * Tells if the test class should be final.
+     *
+     * @return bool
+     */
+    public function testClassFinal(): bool;
+
+    /**
+     * Tells if the test class should declare strict types.
+     *
+     * @return bool
+     */
+    public function testClassStrictTypes(): bool;
+
+    /**
      * Get the case insensitive RegExp (without opening and closing "/") that tested methods shouldn't match.
      *
      * @return array

--- a/src/Renderers/Renderer.php
+++ b/src/Renderers/Renderer.php
@@ -71,9 +71,9 @@ class Renderer implements ConfigAware, RendererContract
     {
         return $this->addLine('use '.$import->getName())
             ->when($import->getAlias(), function (string $alias) {
-                $this->tapLine(fn(RenderedLine $l) => $l->append(' as '.$alias));
+                $this->tapLine(fn (RenderedLine $l) => $l->append(' as '.$alias));
             })
-            ->tapLine(fn(RenderedLine $l) => $l->append(';'));
+            ->tapLine(fn (RenderedLine $l) => $l->append(';'));
     }
 
     /**
@@ -102,10 +102,10 @@ class Renderer implements ConfigAware, RendererContract
 
                 $this->addLine();
             })
-            ->when($class->getDocumentation(), fn(TestDocumentation $d) => $d->accept($this))
+            ->when($class->getDocumentation(), fn (TestDocumentation $d) => $d->accept($this))
             ->addLine("class {$class->getShortName()} extends TestCase")
             ->when($this->config->testClassFinal(), function () {
-                $this->tapLine(fn(RenderedLine $l) => $l->prepend('final '));
+                $this->tapLine(fn (RenderedLine $l) => $l->prepend('final '));
             })
             ->addLine('{')
             ->augmentIndent()
@@ -152,7 +152,7 @@ class Renderer implements ConfigAware, RendererContract
     public function visitTestProperty(TestProperty $property): RendererContract
     {
         return $this
-            ->when($property->getDocumentation(), fn(TestDocumentation $d) => $d->accept($this))
+            ->when($property->getDocumentation(), fn (TestDocumentation $d) => $d->accept($this))
             ->addLine("protected \${$property->getName()};")
             ->addLine();
     }
@@ -163,7 +163,7 @@ class Renderer implements ConfigAware, RendererContract
     public function visitTestMethod(TestMethod $method): RendererContract
     {
         return $this
-            ->when($method->getDocumentation(), fn(TestDocumentation $d) => $d->accept($this))
+            ->when($method->getDocumentation(), fn (TestDocumentation $d) => $d->accept($this))
             ->addLine("{$method->getVisibility()} function {$method->getName()}(")
             ->whenNotEmpty($method->getParameters(), function (Collection $parameters) {
                 $lastKey = $parameters->keys()->last();
@@ -172,11 +172,11 @@ class Renderer implements ConfigAware, RendererContract
                     $parameter->accept($this);
 
                     if ($key !== $lastKey) {
-                        $this->tapLine(fn(RenderedLine $l) => $l->append(', '));
+                        $this->tapLine(fn (RenderedLine $l) => $l->append(', '));
                     }
                 });
             })
-            ->tapLine(fn(RenderedLine $l) => $l->append('): void'))
+            ->tapLine(fn (RenderedLine $l) => $l->append('): void'))
             ->addLine('{')
             ->augmentIndent()
             ->whenNotEmpty($method->getStatements(), function (Collection $statements) {
@@ -186,7 +186,7 @@ class Renderer implements ConfigAware, RendererContract
             })
             ->reduceIndent()
             ->addLine('}')
-            ->when($method->getProvider(), fn(TestProvider $p) => $p->accept($this))
+            ->when($method->getProvider(), fn (TestProvider $p) => $p->accept($this))
             ->addLine();
     }
 
@@ -197,9 +197,9 @@ class Renderer implements ConfigAware, RendererContract
     {
         return $this
             ->when($parameter->getType(), function (string $type) {
-                $this->tapLine(fn(RenderedLine $l) => $l->append($type.' '));
+                $this->tapLine(fn (RenderedLine $l) => $l->append($type.' '));
             })
-            ->tapLine(fn(RenderedLine $l) => $l->append('$'.$parameter->getName()));
+            ->tapLine(fn (RenderedLine $l) => $l->append('$'.$parameter->getName()));
     }
 
     /**
@@ -208,7 +208,7 @@ class Renderer implements ConfigAware, RendererContract
     public function visitTestProvider(TestProvider $provider): RendererContract
     {
         return $this
-            ->when($provider->getDocumentation(), fn(TestDocumentation $d) => $d->accept($this))
+            ->when($provider->getDocumentation(), fn (TestDocumentation $d) => $d->accept($this))
             ->addLine("public function {$provider->getName()}(): array")
             ->addLine('{')
             ->augmentIndent()
@@ -218,7 +218,7 @@ class Renderer implements ConfigAware, RendererContract
 
                 foreach ($data as $datum) {
                     $this->addLine('[')
-                        ->tapLine(fn(RenderedLine $l) => $l->append(implode(', ', $datum).'],'));
+                        ->tapLine(fn (RenderedLine $l) => $l->append(implode(', ', $datum).'],'));
                 }
 
                 $this->reduceIndent();
@@ -249,7 +249,7 @@ class Renderer implements ConfigAware, RendererContract
                 && ! Str::startsWith('//', $lastLine)
                 && ! Str::endsWith('*/', $lastLine)
             ) {
-                $this->tapLine(fn(RenderedLine $l) => $l->append(';'));
+                $this->tapLine(fn (RenderedLine $l) => $l->append(';'));
             }
 
             $this->reduceIndent();
@@ -268,7 +268,7 @@ class Renderer implements ConfigAware, RendererContract
                 $this->addLine(' *');
 
                 if ($line !== '') {
-                    $this->tapLine(fn(RenderedLine $l) => $l->append(' '.$line));
+                    $this->tapLine(fn (RenderedLine $l) => $l->append(' '.$line));
                 }
             });
 

--- a/tests/Feature/Resources/Generators/Basic/Rendered.stub
+++ b/tests/Feature/Resources/Generators/Basic/Rendered.stub
@@ -15,7 +15,7 @@ use Tests\TestCase;
  *
  * @covers \App\Entity\Person
  */
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     /**
      * @var Person

--- a/tests/Feature/Resources/Generators/Laravel/ApiController/Rendered.stub
+++ b/tests/Feature/Resources/Generators/Laravel/ApiController/Rendered.stub
@@ -14,7 +14,7 @@ use Tests\TestCase;
  *
  * @covers \App\Http\Api\Controllers\UserController
  */
-class UserControllerTest extends TestCase
+final class UserControllerTest extends TestCase
 {
     /**
      * @var UserController

--- a/tests/Feature/Resources/Generators/Laravel/Channel/Rendered.stub
+++ b/tests/Feature/Resources/Generators/Laravel/Channel/Rendered.stub
@@ -15,7 +15,7 @@ use Tests\TestCase;
  *
  * @covers \App\Broadcasting\EventChannel
  */
-class EventChannelTest extends TestCase
+final class EventChannelTest extends TestCase
 {
     /**
      * @var EventChannel

--- a/tests/Feature/Resources/Generators/Laravel/Command/Rendered.stub
+++ b/tests/Feature/Resources/Generators/Laravel/Command/Rendered.stub
@@ -14,7 +14,7 @@ use Tests\TestCase;
  *
  * @covers \App\Console\Commands\PruneUsersCommand
  */
-class PruneUsersCommandTest extends TestCase
+final class PruneUsersCommandTest extends TestCase
 {
     /**
      * @var PruneUsersCommand

--- a/tests/Feature/Resources/Generators/Laravel/Controller/Rendered.stub
+++ b/tests/Feature/Resources/Generators/Laravel/Controller/Rendered.stub
@@ -14,7 +14,7 @@ use Tests\TestCase;
  *
  * @covers \App\Http\Controllers\UserController
  */
-class UserControllerTest extends TestCase
+final class UserControllerTest extends TestCase
 {
     /**
      * @var UserController

--- a/tests/Feature/Resources/Generators/Laravel/Job/Rendered.stub
+++ b/tests/Feature/Resources/Generators/Laravel/Job/Rendered.stub
@@ -15,7 +15,7 @@ use Tests\TestCase;
  *
  * @covers \App\Jobs\SendWelcomeMessageJob
  */
-class SendWelcomeMessageJobTest extends TestCase
+final class SendWelcomeMessageJobTest extends TestCase
 {
     /**
      * @var SendWelcomeMessageJob

--- a/tests/Feature/Resources/Generators/Laravel/Listener/Rendered.stub
+++ b/tests/Feature/Resources/Generators/Laravel/Listener/Rendered.stub
@@ -15,7 +15,7 @@ use Tests\TestCase;
  *
  * @covers \App\Listeners\NewUserListener
  */
-class NewUserListenerTest extends TestCase
+final class NewUserListenerTest extends TestCase
 {
     /**
      * @var NewUserListener

--- a/tests/Feature/Resources/Generators/Laravel/Policy/Rendered.stub
+++ b/tests/Feature/Resources/Generators/Laravel/Policy/Rendered.stub
@@ -16,7 +16,7 @@ use Tests\TestCase;
  *
  * @covers \App\Policies\ProductPolicy
  */
-class ProductPolicyTest extends TestCase
+final class ProductPolicyTest extends TestCase
 {
     /**
      * @var ProductPolicy

--- a/tests/Feature/Resources/Generators/Laravel/Resource/Rendered.stub
+++ b/tests/Feature/Resources/Generators/Laravel/Resource/Rendered.stub
@@ -15,7 +15,7 @@ use Tests\TestCase;
  *
  * @covers \App\Http\Resources\ProductResource
  */
-class ProductResourceTest extends TestCase
+final class ProductResourceTest extends TestCase
 {
     /**
      * @var ProductResource

--- a/tests/Feature/Resources/Generators/Laravel/Rule/Rendered.stub
+++ b/tests/Feature/Resources/Generators/Laravel/Rule/Rendered.stub
@@ -14,7 +14,7 @@ use Tests\TestCase;
  *
  * @covers \App\Rules\ProductRule
  */
-class ProductRuleTest extends TestCase
+final class ProductRuleTest extends TestCase
 {
     /**
      * @var ProductRule

--- a/tests/Feature/Resources/Generators/Php8Features/Rendered.stub
+++ b/tests/Feature/Resources/Generators/Php8Features/Rendered.stub
@@ -16,7 +16,7 @@ use Tests\TestCase;
  *
  * @covers \App\Entity\Person
  */
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     /**
      * @var Person

--- a/tests/Feature/Resources/Generators/TypesDetections/Rendered.stub
+++ b/tests/Feature/Resources/Generators/TypesDetections/Rendered.stub
@@ -25,7 +25,7 @@ use Throwable2;
  *
  * @covers \App\Current\TypesDetectionStub
  */
-class TypesDetectionStubTest extends TestCase
+final class TypesDetectionStubTest extends TestCase
 {
     /**
      * @var TypesDetectionStub

--- a/tests/Unit/Config/ConfigTest.php
+++ b/tests/Unit/Config/ConfigTest.php
@@ -19,23 +19,25 @@ class ConfigTest extends TestCase
     public function testWhenDefaultConfiguration(): void
     {
         $this->assertSame([
-            'automaticGeneration' => true,
-            'implementations'     => DelegateTestGenerator::implementations(),
-            'baseNamespace'       => 'App',
-            'baseTestNamespace'   => 'Tests',
-            'testCase'            => 'Tests\\TestCase',
-            'excludedMethods'     => [
+            'automaticGeneration'  => true,
+            'implementations'      => DelegateTestGenerator::implementations(),
+            'baseNamespace'        => 'App',
+            'baseTestNamespace'    => 'Tests',
+            'testCase'             => 'Tests\\TestCase',
+            'testClassFinal'       => true,
+            'testClassStrictTypes' => false,
+            'excludedMethods'      => [
                 '__construct',
                 '__destruct',
             ],
-            'mergedPhpDoc'        => [
+            'mergedPhpDoc'         => [
                 'author',
                 'copyright',
                 'license',
                 'version',
             ],
-            'phpDoc'              => [],
-            'options'             => [
+            'phpDoc'               => [],
+            'options'              => [
                 'context' => 'laravel',
             ],
         ], Config::make()->toArray());
@@ -44,25 +46,29 @@ class ConfigTest extends TestCase
     public function testWhenCompleteConfiguration(): void
     {
         $this->assertSame([
-            'automaticGeneration' => false,
-            'implementations'     => [],
-            'baseNamespace'       => 'App\\',
-            'baseTestNamespace'   => 'App\\Tests\\',
-            'testCase'            => 'App\\Tests\\TestCase',
-            'excludedMethods'     => [],
-            'mergedPhpDoc'        => [],
-            'phpDoc'              => ['@author John Doe'],
-            'options'             => ['custom' => 'option'],
+            'automaticGeneration'  => false,
+            'implementations'      => [],
+            'baseNamespace'        => 'App\\',
+            'baseTestNamespace'    => 'App\\Tests\\',
+            'testCase'             => 'App\\Tests\\TestCase',
+            'testClassFinal'       => false,
+            'testClassStrictTypes' => true,
+            'excludedMethods'      => [],
+            'mergedPhpDoc'         => [],
+            'phpDoc'               => ['@author John Doe'],
+            'options'              => ['custom' => 'option'],
         ], Config::make([
-            'automaticGeneration' => false,
-            'implementations'     => [],
-            'baseNamespace'       => 'App\\',
-            'baseTestNamespace'   => 'App\\Tests\\',
-            'testCase'            => 'App\\Tests\\TestCase',
-            'excludedMethods'     => [],
-            'mergedPhpDoc'        => [],
-            'phpDoc'              => ['@author John Doe'],
-            'options'             => ['custom' => 'option'],
+            'automaticGeneration'  => false,
+            'implementations'      => [],
+            'baseNamespace'        => 'App\\',
+            'baseTestNamespace'    => 'App\\Tests\\',
+            'testCase'             => 'App\\Tests\\TestCase',
+            'testClassFinal'       => false,
+            'testClassStrictTypes' => true,
+            'excludedMethods'      => [],
+            'mergedPhpDoc'         => [],
+            'phpDoc'               => ['@author John Doe'],
+            'options'              => ['custom' => 'option'],
         ])->toArray());
     }
 
@@ -107,15 +113,17 @@ class ConfigTest extends TestCase
     public function testGetters(): void
     {
         $config = Config::make([
-            'automaticGeneration' => false,
-            'implementations'     => [],
-            'baseNamespace'       => 'App\\',
-            'baseTestNamespace'   => 'App\\Tests\\',
-            'testCase'            => 'App\\Tests\\TestCase',
-            'excludedMethods'     => [],
-            'mergedPhpDoc'        => [],
-            'phpDoc'              => ['@author John Doe'],
-            'options'             => ['custom' => 'option'],
+            'automaticGeneration'  => false,
+            'implementations'      => [],
+            'baseNamespace'        => 'App\\',
+            'baseTestNamespace'    => 'App\\Tests\\',
+            'testCase'             => 'App\\Tests\\TestCase',
+            'testClassFinal'       => false,
+            'testClassStrictTypes' => true,
+            'excludedMethods'      => [],
+            'mergedPhpDoc'         => [],
+            'phpDoc'               => ['@author John Doe'],
+            'options'              => ['custom' => 'option'],
         ]);
 
         $this->assertSame(false, $config->automaticGeneration());
@@ -123,6 +131,8 @@ class ConfigTest extends TestCase
         $this->assertSame('App\\', $config->baseNamespace());
         $this->assertSame('App\\Tests\\', $config->baseTestNamespace());
         $this->assertSame('App\\Tests\\TestCase', $config->testCase());
+        $this->assertSame(false, $config->testClassFinal());
+        $this->assertSame(true, $config->testClassStrictTypes());
         $this->assertSame([], $config->excludedMethods());
         $this->assertSame([], $config->mergedPhpDoc());
         $this->assertSame(['@author John Doe'], $config->phpDoc());


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/fix branch** (right side). Don't request your master!
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Description
Resolves #19 by providing two new config options:

- `testClassFinal` (defaults to `true`): Tells if the test class should be final.
- `testClassStrictTypes` (defaults to `false`): Tells if the test class should declare strict types.

This is a breaking change (new option and config interface change), so it should be released on a new major release.